### PR TITLE
Ssl updates - v0.4-snapshot upgrade

### DIFF
--- a/Karamelfile
+++ b/Karamelfile
@@ -6,5 +6,3 @@ dependencies:
   - recipe: livy::default
     global:  
       - hops::dn
-    local:
-      - kagent::default    

--- a/Karamelfile
+++ b/Karamelfile
@@ -6,6 +6,5 @@ dependencies:
   - recipe: livy::default
     global:  
       - hops::dn
-      - hops::nm
     local:
       - kagent::default    

--- a/Karamelfile
+++ b/Karamelfile
@@ -1,8 +1,7 @@
 dependencies: 
   - recipe: livy::install
-    local:  
+    global:  
       - kagent::install
-      - hadoop_spark::install
   - recipe: livy::default
     global:  
       - hops::dn

--- a/Karamelfile
+++ b/Karamelfile
@@ -7,3 +7,5 @@ dependencies:
     global:  
       - hops::dn
       - hops::nm
+    local:
+      - kagent::default    

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ include_attribute "kagent"
 default.livy.user                    = node.install.user.empty? ? node.hadoop_spark.user : node.install.user
 default.livy.group                   = node.install.user.empty? ? node.hadoop_spark.group : node.install.user
 
-default.livy.version                 = "0.3.0-SNAPSHOT"
+default.livy.version                 = "0.4.0-SNAPSHOT"
 default.livy.url                     = "#{node.download_url}/livy-server-#{node.livy.version}.zip"
 default.livy.port                    = "8998"
 default.livy.dir                     = node.install.dir.empty? ? "/srv" : node.install.dir

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -149,3 +149,15 @@ end
 livy_restart "restart-livy-needed" do
   action :restart
 end
+
+
+
+
+bash "jupyter-hdfscontents" do
+    user "root"
+    code <<-EOF
+    set -e
+    export HADOOP_HOME=#{node[:hops][:base_dir]}
+    pip install hdfscontents
+EOF
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -158,6 +158,7 @@ bash "jupyter-hdfscontents" do
     code <<-EOF
     set -e
     export HADOOP_HOME=#{node[:hops][:base_dir]}
-    pip install hdfscontents
+    pip install pydoop
+    pip install 'hdfscontents>=0.4'
 EOF
 end

--- a/templates/default/livy.conf.erb
+++ b/templates/default/livy.conf.erb
@@ -46,3 +46,9 @@ livy.server.csrf_protection.enabled = false
 # sessions.
 # livy.file.local-dir-whitelist =
 
+livy.server.recovery.mode=recovery
+
+livy.server.recovery.state-store=filesystem
+
+livy.server.recovery.state-store.url = file://<%= node[:livy][:base_dir] %>/logs
+

--- a/templates/default/livy.conf.erb
+++ b/templates/default/livy.conf.erb
@@ -21,6 +21,8 @@ livy.spark.master = yarn
 # If livy should impersonate the requesting users when creating a new session.
 livy.impersonation.enabled = true
 
+livy.server.csrf_protection.enabled = false
+
 # Comma-separated list of Livy RSC jars. By default Livy will upload jars from its installation
 # directory every time a session is started. By caching these files in HDFS, for example, startup
 # time of sessions on YARN can be reduced.


### PR DESCRIPTION
Upgrading to v0.4.0 due to issue with livy session names.
Fixing depedencies for SSL suppport.