### PR TITLE
Gpu support requires hopsfs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default.livy.user                    = node.install.user.empty? ? node.hadoop_sp
 default.livy.group                   = node.install.user.empty? ? node.hadoop_spark.group : node.install.user
 
 default.livy.version                 = "0.4.0-SNAPSHOT"
-default.livy.url                     = "#{node.download_url}/livy-server-#{node.livy.version}.zip"
+default.livy.url                     = "#{node.download_url}/gpu/livy-server-#{node.livy.version}.zip"
 default.livy.port                    = "8998"
 default.livy.dir                     = node.install.dir.empty? ? "/srv" : node.install.dir
 default.livy.home                    = node.livy.dir + "/livy-server-" + node.livy.version

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default.livy.user                    = node.install.user.empty? ? node.hadoop_sp
 default.livy.group                   = node.install.user.empty? ? node.hadoop_spark.group : node.install.user
 
 default.livy.version                 = "0.4.0-SNAPSHOT"
-default.livy.url                     = "#{node.download_url}/gpu/livy-server-#{node.livy.version}.zip"
+default.livy.url                     = "#{node.download_url}/test/livy-server-#{node.livy.version}.zip"
 default.livy.port                    = "8998"
 default.livy.dir                     = node.install.dir.empty? ? "/srv" : node.install.dir
 default.livy.home                    = node.livy.dir + "/livy-server-" + node.livy.version


### PR DESCRIPTION
Adds hopsfs support by removing spark and hadoop jar dependencies, and replacing them with Hops-Spark and Hops-Hadoop dependencies.