### PR TITLE
Increase session timeout to ~100 days

### DIFF
--- a/templates/default/livy.conf.erb
+++ b/templates/default/livy.conf.erb
@@ -16,7 +16,7 @@ livy.spark.master = yarn
 
 # Time in milliseconds on how long Livy will wait before timing out an idle session.
 # Default is one hour.
-## livy.server.session.timeout = 3600000
+livy.server.session.timeout = 8600000000
 
 # If livy should impersonate the requesting users when creating a new session.
 livy.impersonation.enabled = true


### PR DESCRIPTION
Machine Learning experiments can be long-running (months) therefore the session timeout should be set accordingly.